### PR TITLE
Utilize standardschema & json-schema to (almost) remove dependency on zod. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.17.4",
       "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
         "ajv": "^6.12.6",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
@@ -32,6 +33,7 @@
         "@types/eventsource": "^1.1.15",
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.12",
+        "@types/json-schema": "^7.0.15",
         "@types/node": "^22.0.2",
         "@types/supertest": "^6.0.2",
         "@types/ws": "^8.5.12",
@@ -1640,6 +1642,11 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "client": "tsx src/cli.ts client"
   },
   "dependencies": {
+    "@standard-schema/spec": "^1.0.0",
     "ajv": "^6.12.6",
     "content-type": "^1.0.5",
     "cors": "^2.8.5",
@@ -85,6 +86,7 @@
     "@types/eventsource": "^1.1.15",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.12",
+    "@types/json-schema": "^7.0.15",
     "@types/node": "^22.0.2",
     "@types/supertest": "^6.0.2",
     "@types/ws": "^8.5.12",

--- a/src/examples/server/jsonResponseStreamableHttp.ts
+++ b/src/examples/server/jsonResponseStreamableHttp.ts
@@ -5,6 +5,7 @@ import { StreamableHTTPServerTransport } from '../../server/streamableHttp.js';
 import { z } from 'zod';
 import { CallToolResult, isInitializeRequest } from '../../types.js';
 import cors from 'cors';
+import { zodToJsonSchema } from 'zod-to-json-schema';
 
 
 // Create an MCP server with implementation details
@@ -18,12 +19,17 @@ const getServer = () => {
     }
   });
 
+  const greetSchema = z.object({
+    name: z.string().describe('Name to greet'),
+  });
+
   // Register a simple tool that returns a greeting
-  server.tool(
+  server.tool (
     'greet',
     'A simple greeting tool',
     {
-      name: z.string().describe('Name to greet'),
+      schema: greetSchema,
+      jsonSchema: zodToJsonSchema(greetSchema)
     },
     async ({ name }): Promise<CallToolResult> => {
       return {
@@ -37,12 +43,17 @@ const getServer = () => {
     }
   );
 
+  const multiGreetSchema = z.object({
+    name: z.string().describe('Name to greet'),
+  });
+
   // Register a tool that sends multiple greetings with notifications
   server.tool(
     'multi-greet',
     'A tool that sends different greetings with delays between them',
     {
-      name: z.string().describe('Name to greet'),
+      schema: multiGreetSchema,
+      jsonSchema: zodToJsonSchema(multiGreetSchema)
     },
     async ({ name }, { sendNotification }): Promise<CallToolResult> => {
       const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));

--- a/src/examples/server/mcpServerOutputSchema.ts
+++ b/src/examples/server/mcpServerOutputSchema.ts
@@ -4,6 +4,7 @@
  * This demonstrates how to easily create tools with structured output
  */
 
+import {zodToJsonSchema} from "zod-to-json-schema";
 import { McpServer } from "../../server/mcp.js";
 import { StdioServerTransport } from "../../server/stdio.js";
 import { z } from "zod";
@@ -15,27 +16,37 @@ const server = new McpServer(
   }
 );
 
+const getWeatherSchema = z.object({
+  city: z.string().describe("City name"),
+  country: z.string().describe("Country code (e.g., US, UK)")
+});
+
+const getWeatherOutputSchema = z.object({
+  temperature: z.object({
+    celsius: z.number(),
+    fahrenheit: z.number()
+  }),
+  conditions: z.enum(["sunny", "cloudy", "rainy", "stormy", "snowy"]),
+  humidity: z.number().min(0).max(100),
+  wind: z.object({
+    speed_kmh: z.number(),
+    direction: z.string()
+  })
+});
+
 // Define a tool with structured output - Weather data
 server.registerTool(
   "get_weather",
   {
     description: "Get weather information for a city",
     inputSchema: {
-      city: z.string().describe("City name"),
-      country: z.string().describe("Country code (e.g., US, UK)")
+      schema: getWeatherSchema,
+      jsonSchema: zodToJsonSchema(getWeatherSchema)
     },
     outputSchema: {
-      temperature: z.object({
-        celsius: z.number(),
-        fahrenheit: z.number()
-      }),
-      conditions: z.enum(["sunny", "cloudy", "rainy", "stormy", "snowy"]),
-      humidity: z.number().min(0).max(100),
-      wind: z.object({
-        speed_kmh: z.number(),
-        direction: z.string()
-      })
-    },
+      schema: getWeatherOutputSchema,
+      jsonSchema: zodToJsonSchema(getWeatherOutputSchema)
+    }
   },
   async ({ city, country }) => {
     // Parameters are available but not used in this example

--- a/src/examples/server/simpleSseServer.ts
+++ b/src/examples/server/simpleSseServer.ts
@@ -3,6 +3,7 @@ import { McpServer } from '../../server/mcp.js';
 import { SSEServerTransport } from '../../server/sse.js';
 import { z } from 'zod';
 import { CallToolResult } from '../../types.js';
+import {zodToJsonSchema} from 'zod-to-json-schema';
 
 /**
  * This example server demonstrates the deprecated HTTP+SSE transport 
@@ -21,12 +22,17 @@ const getServer = () => {
     version: '1.0.0',
   }, { capabilities: { logging: {} } });
 
+  const startNotificationStreamSchema = z.object({
+    interval: z.number().describe('Interval in milliseconds between notifications').default(1000),
+    count: z.number().describe('Number of notifications to send').default(10),
+  });
+
   server.tool(
     'start-notification-stream',
     'Starts sending periodic notifications',
     {
-      interval: z.number().describe('Interval in milliseconds between notifications').default(1000),
-      count: z.number().describe('Number of notifications to send').default(10),
+      schema: startNotificationStreamSchema,
+      jsonSchema: zodToJsonSchema(startNotificationStreamSchema)
     },
     async ({ interval, count }, { sendNotification }): Promise<CallToolResult> => {
       const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));

--- a/src/examples/server/sseAndStreamableHttpCompatibleServer.ts
+++ b/src/examples/server/sseAndStreamableHttpCompatibleServer.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 import { CallToolResult, isInitializeRequest } from '../../types.js';
 import { InMemoryEventStore } from '../shared/inMemoryEventStore.js';
 import cors from 'cors';
+import { zodToJsonSchema } from 'zod-to-json-schema';
 
 /**
  * This example server demonstrates backwards compatibility with both:
@@ -25,13 +26,18 @@ const getServer = () => {
     version: '1.0.0',
   }, { capabilities: { logging: {} } });
 
+  const startNotificationStreamSchema = z.object({
+    interval: z.number().describe('Interval in milliseconds between notifications').default(100),
+    count: z.number().describe('Number of notifications to send (0 for 100)').default(50),
+  });
+
   // Register a simple tool that sends notifications over time
   server.tool(
     'start-notification-stream',
     'Starts sending periodic notifications for testing resumability',
     {
-      interval: z.number().describe('Interval in milliseconds between notifications').default(100),
-      count: z.number().describe('Number of notifications to send (0 for 100)').default(50),
+      schema: startNotificationStreamSchema,
+      jsonSchema: zodToJsonSchema(startNotificationStreamSchema)
     },
     async ({ interval, count }, { sendNotification }): Promise<CallToolResult> => {
       const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));

--- a/src/examples/server/toolWithSampleServer.ts
+++ b/src/examples/server/toolWithSampleServer.ts
@@ -1,6 +1,7 @@
 
 // Run with: npx tsx src/examples/server/toolWithSampleServer.ts
 
+import {zodToJsonSchema} from "zod-to-json-schema";
 import { McpServer } from "../../server/mcp.js";
 import { StdioServerTransport } from "../../server/stdio.js";
 import { z } from "zod";
@@ -10,13 +11,18 @@ const mcpServer = new McpServer({
   version: "1.0.0",
 });
 
+const summarizeSchema = z.object({
+  text: z.string().describe("Text to summarize"),
+});
+
 // Tool that uses LLM sampling to summarize any text
 mcpServer.registerTool(
   "summarize",
   {
     description: "Summarize any text using an LLM",
     inputSchema: {
-      text: z.string().describe("Text to summarize"),
+        schema: summarizeSchema,
+        jsonSchema: zodToJsonSchema(summarizeSchema)
     },
   },
   async ({ text }) => {

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -42,7 +42,7 @@ import { StandardSchemaV1 } from "@standard-schema/spec";
 
 type SchemaArg = {
   schema: StandardSchemaV1;
-  jsonSchema: Record<string, unknown> & { type: "object" };
+  jsonSchema: Record<string, unknown> ;
 }
 
 /**

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -40,7 +40,7 @@ import { Transport } from "../shared/transport.js";
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
 
-type SchemaArg = {
+export type SchemaArg = {
   schema: StandardSchemaV1;
   jsonSchema: Record<string, unknown> ;
 }
@@ -106,26 +106,26 @@ export class McpServer {
     this.server.setRequestHandler(
       ListToolsRequestSchema,
       (): ListToolsResult => ({
-        tools: Object.entries(this._registeredTools).filter(
-          ([, tool]) => tool.enabled,
-        ).map(
-          ([name, tool]): Tool => {
-            const toolDefinition: Tool = {
-              name,
-              title: tool.title,
-              description: tool.description,
-              inputSchema: tool.inputSchema ? tool.inputSchema.jsonSchema : EMPTY_OBJECT_JSON_SCHEMA,
-              annotations: tool.annotations,
-            };
+          tools: Object.entries(this._registeredTools).filter(
+            ([, tool]) => tool.enabled,
+          ).map(
+            ([name, tool]): Tool => {
+              const toolDefinition: Tool = {
+                name,
+                title: tool.title,
+                description: tool.description,
+                inputSchema: tool.inputSchema ? tool.inputSchema.jsonSchema : EMPTY_OBJECT_JSON_SCHEMA,
+                annotations: tool.annotations,
+              };
 
-            if (tool.outputSchema) {
-              toolDefinition.outputSchema = tool.outputSchema.jsonSchema;
-            }
+              if (tool.outputSchema) {
+                toolDefinition.outputSchema = tool.outputSchema.jsonSchema;
+              }
 
-            return toolDefinition;
-          },
-        ),
-      }),
+              return toolDefinition;
+            },
+          ),
+        }),
     );
 
     this.server.setRequestHandler(
@@ -1288,5 +1288,5 @@ const EMPTY_COMPLETION_RESULT: CompleteResult = {
 };
 
 const isSchemaArg = (schema: unknown): schema is SchemaArg => {
-  return typeof schema === 'object' && schema !== null && 'schema' in schema && 'toJsonSchema' in schema;
+  return typeof schema === 'object' && schema !== null && 'schema' in schema && 'jsonSchema' in schema;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -908,7 +908,7 @@ export const ToolSchema = BaseMetadataSchema.extend({
    */
   inputSchema: z
     .object({
-      type: z.string().optional(),
+      type: z.literal("object"),
       properties: z.optional(z.object({}).passthrough()),
       required: z.optional(z.array(z.string())),
     })
@@ -919,11 +919,10 @@ export const ToolSchema = BaseMetadataSchema.extend({
    */
   outputSchema: z.optional(
     z.object({
-      type: z.string().optional(),
+      type: z.literal("object"),
       properties: z.optional(z.object({}).passthrough()),
       required: z.optional(z.array(z.string())),
-    })
-      .passthrough()
+    }).passthrough()
   ),
   /**
    * Optional additional tool information.

--- a/src/types.ts
+++ b/src/types.ts
@@ -908,7 +908,7 @@ export const ToolSchema = BaseMetadataSchema.extend({
    */
   inputSchema: z
     .object({
-      type: z.literal("object"),
+      type: z.string().optional(),
       properties: z.optional(z.object({}).passthrough()),
       required: z.optional(z.array(z.string())),
     })
@@ -919,7 +919,7 @@ export const ToolSchema = BaseMetadataSchema.extend({
    */
   outputSchema: z.optional(
     z.object({
-      type: z.literal("object"),
+      type: z.string().optional(),
       properties: z.optional(z.object({}).passthrough()),
       required: z.optional(z.array(z.string())),
     })

--- a/src/types.ts
+++ b/src/types.ts
@@ -908,7 +908,7 @@ export const ToolSchema = BaseMetadataSchema.extend({
    */
   inputSchema: z
     .object({
-      type: z.literal("object"),
+      type: z.string().optional(),
       properties: z.optional(z.object({}).passthrough()),
       required: z.optional(z.array(z.string())),
     })
@@ -919,7 +919,7 @@ export const ToolSchema = BaseMetadataSchema.extend({
    */
   outputSchema: z.optional(
     z.object({
-      type: z.literal("object"),
+      type: z.string().optional(),
       properties: z.optional(z.object({}).passthrough()),
       required: z.optional(z.array(z.string())),
     }).passthrough()


### PR DESCRIPTION
Instead of just passing `schema` to a tool - now the schema has been broken out into two different properties:

```ts
inputSchema: {
    schema: StandardSchemaV1 // compatible with zod, valibot, etc
    jsonSchema: Record<string, unknown> // left up to the developer using the framework to geerate the json schema 
}
```